### PR TITLE
Allow null value for ingressControllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial implementation ([#1])
 - Default wildcard cert ([#2])
 
+### Fixed
+- Allow `null` value for `ingressControllers` ([#3])
+
 [Unreleased]: https://github.com/appuio/component-openshift4-ingress/compare/44356edb4db73e762cd8896fb3b5a6f11f698799...HEAD
 
 [#1]: https://github.com/appuio/component-openshift4-ingress/pull/1
 [#2]: https://github.com/appuio/component-openshift4-ingress/pull/2
+[#3]: https://github.com/appuio/component-openshift4-ingress/pull/3

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -16,6 +16,8 @@ See the https://docs.openshift.com/container-platform/4.4/networking/ingress-ope
 
 The `domain` parameter is required.
 
+To remove all ingress controllers, set to `null`.
+
 
 == `cloud.provider`
 


### PR DESCRIPTION
With [1] merged we can remove dicts and lists by setting them to `null`
in the hierarchy. The components need to actually support null values.

[1] https://github.com/deepmind/kapitan/pull/562

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
