### PR TITLE
Add support for configuring custom certificates via component parameters

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -18,3 +18,6 @@ parameters:
             matchLabels:
               node-role.kubernetes.io/infra: ""
     ingressControllerAnnotations: {}
+
+    secrets: {}
+    cert_manager_certs: {}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -57,7 +57,7 @@ local extraCerts = [
       namespace: params.namespace,
     },
     spec+: {
-      secretName: '%s-tls' % cname,
+      secretName: '%s' % cname,
     },
   } + com.makeMergeable(params.cert_manager_certs[c])
   for c in std.objectFields(params.cert_manager_certs)

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -56,6 +56,9 @@ local extraCerts = [
     metadata+: {
       namespace: params.namespace,
     },
+    spec+: {
+      secretName: '%s-tls' % cname,
+    },
   } + com.makeMergeable(params.cert_manager_certs[c])
   for c in std.objectFields(params.cert_manager_certs)
 ];

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -156,8 +156,7 @@ default:: `{}`
 
 Each entry in parameter `cert_manager_certs` is deployed onto the cluster as a cert-manager `Certificate` resource.
 
-The dictionary keys are used as `metadata.name` for the resulting `Certificate` resources.
-The component also uses the dictionary keys to generate a default value of `<key>-tls` for the field `spec.secretName`.
+The dictionary keys are used as `metadata.name` and `spec.secretName` for the resulting `Certificate` resources.
 The dictionary values are then directly directly merged into the mostly empty `Certificate` resources.
 
 == Examples
@@ -208,7 +207,7 @@ parameters:
           # `prod-wildcard-tls` for certificate resource `prod-wildcard`
           name: prod-wildcard-tls
     cert_manager_certificates:
-      prod-wildcard:
+      prod-wildcard-tls:
         spec:
           dnsNames:
             - '*.apps.example.com'

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -135,8 +135,34 @@ kubectl get secret ingress-cert-issuer-credentials \
   base64 --decode
 --
 
+== `secrets`
 
-== Example
+[horizontal]
+type:: dictionary
+default:: `{}`
+
+Each entry in parameter `secrets` is deployed onto the cluster as a Kubernetes Secret with `type=kubernetes.io/tls`.
+The component has basic validation to ensure the secret contents are a plausible Kubernetes TLS secret.
+
+The dictionary keys are used as `metadata.name` for the resulting `Secret` resources.
+The dictionary values are directly directly merged into a `Secret` resource which only has `type=kubernetes.io/tls` set.
+The secrets are created in the namespace indicated by parameter `namespace`.
+
+== `cert_manager_certs`
+
+[horizontal]
+type:: dictionary
+default:: `{}`
+
+Each entry in parameter `cert_manager_certs` is deployed onto the cluster as a cert-manager `Certificate` resource.
+
+The dictionary keys are used as `metadata.name` for the resulting `Certificate` resources.
+The component also uses the dictionary keys to generate a default value of `<key>-tls` for the field `spec.secretName`.
+The dictionary values are then directly directly merged into the mostly empty `Certificate` resources.
+
+== Examples
+
+=== Managing a secret for the wildcard certificate
 
 [source,yaml]
 ----
@@ -146,6 +172,7 @@ parameters:
       prod:
         domain: apps.example.com
         defaultCertificate:
+          # Use the secret configured below
           name: prod-wildcard
         namespaceSelector:
           matchLabels:
@@ -153,4 +180,39 @@ parameters:
     ingressControllerAnnotations:
       prod:
         ingress.operator.openshift.io/default-enable-http2: true
+    secrets:
+      prod-wildcard:
+        stringData:
+          tls.key: "?{vaultkv:...}" # reference to private key in Vault
+          tls.crt: "?{vaultkv:...}" # reference to cert in Vault
+----
+
+=== Managing a cert-manager wildcard certificate
+
+[NOTE]
+====
+This requires an issuer which supports DNS01 challenges.
+See the xref:cert-manager:ROOT:how-tos/dns01.adoc[Using DNS01 challenges] how-to for component cert-manager to get started with DNS01 challenges.
+====
+
+[source,yaml]
+----
+parameters:
+  openshift4_ingress:
+    ingressControllers:
+      prod:
+        domain: apps.example.com
+        defaultCertificate:
+          # Use the secret for the certificate below.
+          # By default, the component creates a secret with name
+          # `prod-wildcard-tls` for certificate resource `prod-wildcard`
+          name: prod-wildcard-tls
+    cert_manager_certificates:
+      prod-wildcard:
+        spec:
+          dnsNames:
+            - '*.apps.example.com'
+          issuerRef:
+            name: letsencrypt-production
+            kind: ClusterIssuer
 ----

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -145,7 +145,7 @@ Each entry in parameter `secrets` is deployed onto the cluster as a Kubernetes S
 The component has basic validation to ensure the secret contents are a plausible Kubernetes TLS secret.
 
 The dictionary keys are used as `metadata.name` for the resulting `Secret` resources.
-The dictionary values are directly directly merged into a `Secret` resource which only has `type=kubernetes.io/tls` set.
+The dictionary values are directly merged into a `Secret` resource which only has `type=kubernetes.io/tls` set.
 The secrets are created in the namespace indicated by parameter `namespace`.
 
 == `cert_manager_certs`

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -2,7 +2,7 @@ parameters:
   kapitan:
     dependencies:
       - type: https
-        source: https://raw.githubusercontent.com/projectsyn/component-cert-manager/v2.0.1/lib/cert-manager.libsonnet
+        source: https://raw.githubusercontent.com/projectsyn/component-cert-manager/v2.1.0/lib/cert-manager.libsonnet
         output_path: vendor/lib/cert-manager.libsonnet
       - type: https
         source: https://raw.githubusercontent.com/projectsyn/component-resource-locker/v2.0.0/lib/resource-locker.libjsonnet
@@ -10,3 +10,22 @@ parameters:
 
   resource_locker:
     namespace: syn-resource-locker
+
+  openshift4_ingress:
+    secrets:
+      test:
+        stringData:
+          tls.crt: "THECERTTIFICATE"
+          tls.key: "THEKEY"
+
+    cert_manager_certs:
+      test:
+        subject:
+          organizations:
+            - projectsyn
+        dnsNames:
+          - example.com
+          - www.example.com
+        issuerRef:
+          name: letsencrypt-production
+          kind: ClusterIssuer

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -2,7 +2,7 @@ parameters:
   kapitan:
     dependencies:
       - type: https
-        source: https://raw.githubusercontent.com/projectsyn/component-cert-manager/v2.1.0/lib/cert-manager.libsonnet
+        source: https://raw.githubusercontent.com/projectsyn/component-cert-manager/v2.2.0/lib/cert-manager.libsonnet
         output_path: vendor/lib/cert-manager.libsonnet
       - type: https
         source: https://raw.githubusercontent.com/projectsyn/component-resource-locker/v2.0.0/lib/resource-locker.libjsonnet

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -19,7 +19,7 @@ parameters:
           tls.key: "THEKEY"
 
     cert_manager_certs:
-      test:
+      test-tls:
         subject:
           organizations:
             - projectsyn

--- a/tests/golden/defaults/openshift4-ingress/openshift4-ingress/10_extra_certificates.yaml
+++ b/tests/golden/defaults/openshift4-ingress/openshift4-ingress/10_extra_certificates.yaml
@@ -1,0 +1,19 @@
+apiVersion: cert-manager.io/v1alpha2
+dnsNames:
+  - example.com
+  - www.example.com
+issuerRef:
+  kind: ClusterIssuer
+  name: letsencrypt-production
+kind: Certificate
+metadata:
+  annotations: {}
+  labels:
+    name: test
+  name: test
+  namespace: openshift-ingress
+spec:
+  secretName: test-tls
+subject:
+  organizations:
+    - projectsyn

--- a/tests/golden/defaults/openshift4-ingress/openshift4-ingress/10_extra_certificates.yaml
+++ b/tests/golden/defaults/openshift4-ingress/openshift4-ingress/10_extra_certificates.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 dnsNames:
   - example.com
   - www.example.com

--- a/tests/golden/defaults/openshift4-ingress/openshift4-ingress/10_extra_certificates.yaml
+++ b/tests/golden/defaults/openshift4-ingress/openshift4-ingress/10_extra_certificates.yaml
@@ -9,8 +9,8 @@ kind: Certificate
 metadata:
   annotations: {}
   labels:
-    name: test
-  name: test
+    name: test-tls
+  name: test-tls
   namespace: openshift-ingress
 spec:
   secretName: test-tls

--- a/tests/golden/defaults/openshift4-ingress/openshift4-ingress/10_extra_secrets.yaml
+++ b/tests/golden/defaults/openshift4-ingress/openshift4-ingress/10_extra_secrets.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    name: test
+  name: test
+  namespace: openshift-ingress
+stringData:
+  tls.crt: THECERTTIFICATE
+  tls.key: THEKEY
+type: kubernetes.io/tls


### PR DESCRIPTION
This PR introduces new component parameters `secrets` and `cert_manager_certs` which can be used to manage the router default certificate via the configuration hierarchy.

Parameter `secrets` is intended for cases where a wildcard certificate has been purchased from a certificate authority.

Parameter `cert_manager_certs` allows users to configure a `Certificate` resource to request a wildcard certificate from a cert-manager issuer present on the cluster.

Fixes #16 

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.
- [x] Rebase after #23 is merged
- [x] Use new cert-manager component lib version once https://github.com/projectsyn/component-cert-manager/pull/38 is merged.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
