### PR TITLE
Add support to remove extra secrets and certificates

### DIFF
--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -142,6 +142,9 @@ type:: dictionary
 default:: `{}`
 
 Each entry in parameter `secrets` is deployed onto the cluster as a Kubernetes Secret with `type=kubernetes.io/tls`.
+Entries with `null` values are skipped.
+This allows users to remove secrets which were configured higher up in the hierarchy.
+
 The component has basic validation to ensure the secret contents are a plausible Kubernetes TLS secret.
 
 The dictionary keys are used as `metadata.name` for the resulting `Secret` resources.
@@ -155,6 +158,8 @@ type:: dictionary
 default:: `{}`
 
 Each entry in parameter `cert_manager_certs` is deployed onto the cluster as a cert-manager `Certificate` resource.
+Entries with `null` values are skipped.
+This allows users to remove certificates which were configured higher up in the hierarchy.
 
 The dictionary keys are used as `metadata.name` and `spec.secretName` for the resulting `Certificate` resources.
 The dictionary values are then directly directly merged into the mostly empty `Certificate` resources.


### PR DESCRIPTION
In some cases, users may want to remove extra secrets or certificates which were configured higher up in the hierarchy.

This commit implements support to remove secrets or certificates by setting the key in the parameter to `null`.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
