### PR TITLE
Aggregate `ingresscontrollers` into `cluster-reader`

### DIFF
--- a/component/aggregated-clusterroles.libsonnet
+++ b/component/aggregated-clusterroles.libsonnet
@@ -1,0 +1,25 @@
+local kube = import 'lib/kube.libjsonnet';
+
+local cluster_reader =
+  kube.ClusterRole('syn:openshift4-ingress:cluster-reader') {
+    metadata+: {
+      labels+: {
+        'rbac.authorization.k8s.io/aggregate-to-cluster-reader': 'true',
+      },
+    },
+    rules: [
+      {
+        apiGroups: [ 'operator.openshift.io' ],
+        resources: [ 'ingresscontrollers' ],
+        verbs: [
+          'get',
+          'list',
+          'watch',
+        ],
+      },
+    ],
+  };
+
+[
+  cluster_reader,
+]

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -106,6 +106,7 @@ if std.length(ingressControllers) > 0 then
     for name in ingressControllers
   } + {
     '00_label_patches': defaultNamespacePatch,
+    '01_aggregated_clusterroles': (import 'aggregated-clusterroles.libsonnet'),
     [if anyControllerUsesAcme then 'acmeIssuer']: acme.issuer,
     [if std.length(extraSecrets) > 0 then '10_extra_secrets']: extraSecrets,
     [if std.length(extraCerts) > 0 then '10_extra_certificates']: extraCerts,

--- a/tests/golden/defaults/openshift4-ingress/openshift4-ingress/01_aggregated_clusterroles.yaml
+++ b/tests/golden/defaults/openshift4-ingress/openshift4-ingress/01_aggregated_clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-openshift4-ingress-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn:openshift4-ingress:cluster-reader
+rules:
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - ingresscontrollers
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
We add a custom clusterrole which is aggregated to `cluster-reader` which grants `get`, `list`, `watch` on all `monitoring.coreos.com` resources. This should allow users which have cluster-reader look at Prometheus rules, ServiceMonitors etc. without having to impersonate cluster-admin.

## Checklist

- [X] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [X] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [X] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
