### PR TITLE
Add option to patch the router pods to run in dual stack mode

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -21,5 +21,13 @@ parameters:
               node-role.kubernetes.io/infra: ""
     ingressControllerAnnotations: {}
 
+    patchDualStack:
+      enabled: false
+      objectSelector:
+        matchExpressions:
+          - key: 'ingresscontroller.operator.openshift.io/deployment-ingresscontroller'
+            operator: 'Exists'
+
+
     secrets: {}
     cert_manager_certs: {}

--- a/component/espejote-templates/ingress-router-dualstack.jsonnet
+++ b/component/espejote-templates/ingress-router-dualstack.jsonnet
@@ -1,0 +1,37 @@
+local esp = import 'espejote.libsonnet';
+local admission = esp.ALPHA.admission;
+
+local pod = admission.admissionRequest().object;
+
+local cids = std.find('router', std.map(function(c) c.name, pod.spec.containers));
+assert std.length(cids) == 1 : "Expected to find a single container with name 'router'";
+local containerIndex = cids[0];
+
+// Asserts against null.
+// We could just add an empty array as env before the patch and don't fail but it might be better for someone to check what changed.
+local env = std.get(pod.spec.containers[containerIndex], 'env');
+assert std.isArray(env) : 'Expected container env to be an array, is: %s' % std.type(env);
+
+// Try to find ROUTER_IP_V4_V6_MODE envvar in the container
+// Fail if we find it more than once.
+local eids = std.find('ROUTER_IP_V4_V6_MODE', std.map(function(e) e.name, pod.spec.containers[containerIndex].env));
+assert std.length(eids) <= 1 : "Expected to find at most one envvar named 'ROUTER_IP_V4_V6_MODE'";
+
+local containerPath = '/spec/containers/%s' % containerIndex;
+local env_v4v6 = { name: 'ROUTER_IP_V4_V6_MODE', value: 'v4v6' };
+
+// Overwrite or add the ROUTER_IP_V4_V6_MODE envvar in the container
+local patch = if std.length(eids) == 1 then
+  admission.jsonPatchOp(
+    'replace',
+    containerPath + '/env/%d' % eids[0],
+    env_v4v6,
+  )
+else
+  admission.jsonPatchOp(
+    'add',
+    containerPath + '/env/-',
+    env_v4v6,
+  );
+
+admission.patched('added dualstack env', admission.assertPatch([ patch ]))

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -194,6 +194,8 @@ if std.length(ingressControllers) > 0 then
     [if anyControllerUsesAcme then 'acmeIssuer']: acme.issuer,
     [if std.length(extraSecrets) > 0 then '10_extra_secrets']: extraSecrets,
     [if std.length(extraCerts) > 0 then '10_extra_certificates']: extraCerts,
+    [if params.patchDualStack.enabled then '99_patch_dual_stack']:
+      import 'patch-dual-stack.libsonnet',
   }
 else
   // if no ingressControllers are configured, only emit an empty `.gitkeep`

--- a/component/patch-dual-stack.libsonnet
+++ b/component/patch-dual-stack.libsonnet
@@ -1,0 +1,25 @@
+local esp = import 'lib/espejote.libsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local inv = kap.inventory();
+
+local params = inv.parameters.openshift4_ingress;
+
+[
+  esp.admission('ingress-router-set-dualstack', params.namespace) {
+    spec: {
+      mutating: true,
+      template: importstr 'espejote-templates/ingress-router-dualstack.jsonnet',
+      webhookConfiguration: {
+        rules: [
+          {
+            apiGroups: [ '' ],
+            apiVersions: [ '*' ],
+            operations: [ 'CREATE' ],
+            resources: [ 'pods' ],
+          },
+        ],
+        objectSelector: params.patchDualStack.objectSelector,
+      },
+    },
+  },
+]

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -135,6 +135,29 @@ kubectl get secret ingress-cert-issuer-credentials \
   base64 --decode
 --
 
+== `patchDualStack`
+
+[horizontal]
+type:: dictionary
+
+=== `patchDualStack.enabled`
+
+[horizontal]
+type:: bool
+default:: `false`
+
+When this parameter is set to true, the component deploys an Espejote `Admission` mutating webhook which intercepts newly created router pods and sets environment variable `ROUTER_IP_V4_V6_MODE` to `v4v6`.
+
+=== `patchDualStack.objectSelector`
+
+[horizontal]
+type:: dictionary
+default:: See https://github.com/appuio/component-openshift4-ingress/blob/master/class/defaults.yml[`class/defaults.yml`]
+
+The value of this parameter is used as is for the Espejote `Admission`'s `webhookConfiguration.objectSelector` field.
+By default, the component configures the webhook to select all router pods.
+Users can override this parameter to only select a subset of router pods.
+
 == `secrets`
 
 [horizontal]

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -15,6 +15,9 @@ parameters:
           tls.crt: "THECERTTIFICATE"
           tls.key: "THEKEY"
 
+    patchDualStack:
+      enabled: true
+
     cert_manager_certs:
       test-tls:
         subject:

--- a/tests/golden/defaults/openshift4-ingress/openshift4-ingress/99_patch_dual_stack.yaml
+++ b/tests/golden/defaults/openshift4-ingress/openshift4-ingress/99_patch_dual_stack.yaml
@@ -1,0 +1,61 @@
+apiVersion: espejote.io/v1alpha1
+kind: Admission
+metadata:
+  labels:
+    app.kubernetes.io/name: ingress-router-set-dualstack
+  name: ingress-router-set-dualstack
+  namespace: openshift-ingress
+spec:
+  mutating: true
+  template: |
+    local esp = import 'espejote.libsonnet';
+    local admission = esp.ALPHA.admission;
+
+    local pod = admission.admissionRequest().object;
+
+    local cids = std.find('router', std.map(function(c) c.name, pod.spec.containers));
+    assert std.length(cids) == 1 : "Expected to find a single container with name 'router'";
+    local containerIndex = cids[0];
+
+    // Asserts against null.
+    // We could just add an empty array as env before the patch and don't fail but it might be better for someone to check what changed.
+    local env = std.get(pod.spec.containers[containerIndex], 'env');
+    assert std.isArray(env) : 'Expected container env to be an array, is: %s' % std.type(env);
+
+    // Try to find ROUTER_IP_V4_V6_MODE envvar in the container
+    // Fail if we find it more than once.
+    local eids = std.find('ROUTER_IP_V4_V6_MODE', std.map(function(e) e.name, pod.spec.containers[containerIndex].env));
+    assert std.length(eids) <= 1 : "Expected to find at most one envvar named 'ROUTER_IP_V4_V6_MODE'";
+
+    local containerPath = '/spec/containers/%s' % containerIndex;
+    local env_v4v6 = { name: 'ROUTER_IP_V4_V6_MODE', value: 'v4v6' };
+
+    // Overwrite or add the ROUTER_IP_V4_V6_MODE envvar in the container
+    local patch = if std.length(eids) == 1 then
+      admission.jsonPatchOp(
+        'replace',
+        containerPath + '/env/%d' % eids[0],
+        env_v4v6,
+      )
+    else
+      admission.jsonPatchOp(
+        'add',
+        containerPath + '/env/-',
+        env_v4v6,
+      );
+
+    admission.patched('added dualstack env', admission.assertPatch([ patch ]))
+  webhookConfiguration:
+    objectSelector:
+      matchExpressions:
+        - key: ingresscontroller.operator.openshift.io/deployment-ingresscontroller
+          operator: Exists
+    rules:
+      - apiGroups:
+          - ''
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+        resources:
+          - pods


### PR DESCRIPTION
When enabled, the component deploys an Espejote `Admission` mutating webhook which injects environment variable `ROUTER_IP_V4_V6_MODE` with value `v4v6` into newly created OpenShift ingress router pods.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
